### PR TITLE
Do not fail when the language is not supported. Instead, falls back t…

### DIFF
--- a/.changeset/nasty-chairs-refuse.md
+++ b/.changeset/nasty-chairs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@jcayzac/shiki-highlighter": patch
+---
+
+Do not fail when the language is not supported. Instead, falls back to `plaintext`.

--- a/packages/shiki-highlighter/src/index.ts
+++ b/packages/shiki-highlighter/src/index.ts
@@ -76,9 +76,10 @@ export interface HighlightOptions {
 }
 
 function highlight(code: string, options: HighlightOptions = {}): string {
-	const lang = options.lang ?? 'plaintext'
+	let lang = options.lang ?? 'plaintext'
 	if (!langs.has(lang as BuiltinLanguage) && !langAlias[lang]) {
-		throw new Error(`Language "${lang}" is not supported. Supported languages are:\n${[...langs].join(', ')}`)
+		console.warn(`@jcayzac/shiki-highlighter doesn't support the "${lang}" language. Supported languages are:\n${[...langs].join(', ')}`)
+		lang = 'plaintext'
 	}
 
 	const { meta, inline } = options


### PR DESCRIPTION
…o `plaintext`.